### PR TITLE
Fixed to only throw exception on even root

### DIFF
--- a/src/main/java/com/kamefrede/rpsideas/spells/operator/math/PieceOperatorRoot.java
+++ b/src/main/java/com/kamefrede/rpsideas/spells/operator/math/PieceOperatorRoot.java
@@ -29,7 +29,7 @@ public class PieceOperatorRoot extends PieceOperator {
     public Object execute(SpellContext context) throws SpellRuntimeException {
         double base = SpellHelpers.getNumber(this, context, num, 0);
         double r = SpellHelpers.getNumber(this, context, root, 1);
-        if (base < 0 && r % 2 != 0)
+        if (base < 0 && r % 2 == 0)
             throw new SpellRuntimeException(SpellRuntimeExceptions.EVEN_ROOT_NEGATIVE_NUMBER);
         return Math.pow(base, 1.0 / r);
 


### PR DESCRIPTION
Previously, code was throwing EVEN_ROOT_NEGATIVE_NUMBER exceptions only when base was negative and r % 2 != 0 which is only when r is odd. 

Fixed to throw exception when root is even and base is negative.