### PR TITLE
Fixed bounding box for "Visible Entity" entity selection

### DIFF
--- a/src/main/java/com/kamefrede/rpsideas/spells/selector/PieceSelectorVisibleEntities.java
+++ b/src/main/java/com/kamefrede/rpsideas/spells/selector/PieceSelectorVisibleEntities.java
@@ -52,7 +52,7 @@ public class PieceSelectorVisibleEntities extends PieceSelector {
         if (!context.isInRadius(pos))
             throw new SpellRuntimeException(SpellRuntimeException.OUTSIDE_RADIUS);
         else {
-            AxisAlignedBB axis = new AxisAlignedBB(pos.x, pos.y - radiusVal, pos.z - radiusVal, pos.x + radiusVal, pos.y + radiusVal, pos.z + radiusVal);
+            AxisAlignedBB axis = new AxisAlignedBB(pos.x - radiusVal, pos.y - radiusVal, pos.z - radiusVal, pos.x + radiusVal, pos.y + radiusVal, pos.z + radiusVal);
             Predicate<Entity> targetPredicate = this.getTargetPredicate();
             List<Entity> list = context.caster.world.getEntitiesWithinAABB(Entity.class, axis,
                     (e) -> e != null && targetPredicate.test(e) &&


### PR DESCRIPTION
Just a simple bugfix for VisibleEntity Selector. Was previously only able to select entities with a greater x than the entity whenever a positive radius was used. 